### PR TITLE
버그:  #13 ubuntu 환경에서 make 되지 않는 버그 수정

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ OBJS = $(SRCS:.c=.o)
 all: make_libft $(NAME)
 
 $(NAME): $(OBJS)
-	$(CC) $(LIBFT)/libft.a $(CFLAG) $(LIBS) -I./ -o $(NAME) $(OBJS)
+	$(CC) $(CFLAG) -I./ -o $(NAME) $(OBJS) $(LIBFT)/libft.a $(LIBS)
 
 make_libft:
 	make -C $(LIBFT)


### PR DESCRIPTION
링커의 호출 순서에 영향을 받기 때문에 발생.

1. 오브젝트 파일
2. LIB 
3. LIBS
순서로 호출하도록 순서 변경. 